### PR TITLE
New logging system

### DIFF
--- a/Framework/Logging.cs
+++ b/Framework/Logging.cs
@@ -1,173 +1,175 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+//using System;
+//using System.Collections.Generic;
+//using System.IO;
+//using System.IO.Compression;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
+
+// New logger in utilities
+// Do not remove - some things are going to get integrated, i.e. archiving
+
+//namespace OriBot.Framework
+//{
+//    public class Logging
+//    {
+//        private static Logger logger;
+
+//        static Logging() // dont remove this (reminder for slam)
+//        {
+//            logger = new Logger();
+//        }
+
+//        public static void Debug(string message)
+//        {
+//            logger.Debug(message);
+//        }
+
+//        public static void Info(string message)
+//        {
+//            logger.Info(message);
+//        }
+
+//        public static void Warn(string message)
+//        {
+//            logger.Warn(message);
+//        }
+
+//        public static void Error(string message)
+//        {
+//            logger.Error(message);
+//        }
+
+//        public static void Cleanup()
+//        {
+//            logger.tryPack();
+//        }
+//    }
+
+//    public enum LogLevel
+//    {
+//        DEBUG,
+//        INFO,
+//        WARN,
+//        ERROR
+//    }
+
+//    public sealed class Logger
+//    {
+//        // FIXME: Add to config
+//        public bool isDebug = true;
+//        private string _filePath { get; set; }
+//        private string _appName = "Oribot-v5.0.0";
+//        private string _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
 
-namespace OriBot.Framework
-{
-    public class Logging
-    {
-        private static Logger logger;
+//        public Logger()
+//        {
+//            string logFolderPath = Path.Combine(_appDataFolder, _appName, "Logs");
 
-        static Logging() // dont remove this (reminder for slam)
-        {
-            logger = new Logger();
-        }
+//            // create the directory if it doesn't exist
+//            if (!Directory.Exists(logFolderPath))
+//            {
+//                Directory.CreateDirectory(logFolderPath);
+//            }
 
-        public static void Debug(string message)
-        {
-            logger.Debug(message);
-        }
+//            this._filePath = Path.Combine(logFolderPath, "latest.log");
+//        }
 
-        public static void Info(string message)
-        {
-            logger.Info(message);
-        }
+//        public void tryPack()
+//        {
+//            // FIXME:
+//            // can you, get this working properly xd
+//            // I aim it to go like uhhhh
+//            // \OribotAppdataFolder (we can change that later)
+//            //      L latest.log
+//            //      L \.old 
+//            //          L {date}.gz
+//            //
+//            string compressedFolderPath = Path.Combine(_appDataFolder, _appName, "Logs", ".old");
 
-        public static void Warn(string message)
-        {
-            logger.Warn(message);
-        }
+//            if (!Directory.Exists(compressedFolderPath))
+//            {
+//                Directory.CreateDirectory(compressedFolderPath);
+//            }
 
-        public static void Error(string message)
-        {
-            logger.Error(message);
-        }
+//            string newName = Path.Combine(_filePath, $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")}.log");
 
-        public static void Cleanup()
-        {
-            logger.tryPack();
-        }
-    }
+//            RenameFile(_filePath, newName);
+//            CompressLogFile(_filePath, compressedFolderPath);
+//        }
 
-    public enum LogLevel
-    {
-        DEBUG,
-        INFO,
-        WARN,
-        ERROR
-    }
+//        private void CompressLogFile(string sourceFilePath, string compressedFilePath)
+//        {
+//            try
+//            {
+//                using (var sourceStream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read))
+//                {
+//                    using (var compressedFileStream = new FileStream(compressedFilePath, FileMode.Create, FileAccess.Write))
+//                    {
+//                        using (var gzipStream = new GZipStream(compressedFileStream, CompressionMode.Compress))
+//                        {
+//                            sourceStream.CopyTo(gzipStream);
+//                        }
+//                    }
+//                }
+//            }
+//            catch (Exception ex)
+//            {
+//                Console.WriteLine($"Error compressing the log file: {ex.Message}");
+//            }
+//        }
 
-    public sealed class Logger
-    {
-        // FIXME: Add to config
-        public bool isDebug = true;
-        private string _filePath { get; set; }
-        private string _appName = "Oribot-v5.0.0";
-        private string _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-
-
-        public Logger()
-        {
-            string logFolderPath = Path.Combine(_appDataFolder, _appName, "Logs");
-
-            // create the directory if it doesn't exist
-            if (!Directory.Exists(logFolderPath))
-            {
-                Directory.CreateDirectory(logFolderPath);
-            }
-
-            this._filePath = Path.Combine(logFolderPath, "latest.log");
-        }
-
-        public void tryPack()
-        {
-            // FIXME:
-            // can you, get this working properly xd
-            // I aim it to go like uhhhh
-            // \OribotAppdataFolder (we can change that later)
-            //      L latest.log
-            //      L \.old 
-            //          L {date}.gz
-            //
-            string compressedFolderPath = Path.Combine(_appDataFolder, _appName, "Logs", ".old");
-
-            if (!Directory.Exists(compressedFolderPath))
-            {
-                Directory.CreateDirectory(compressedFolderPath);
-            }
-
-            string newName = Path.Combine(_filePath, $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")}.log");
-
-            RenameFile(_filePath, newName);
-            CompressLogFile(_filePath, compressedFolderPath);
-        }
-
-        private void CompressLogFile(string sourceFilePath, string compressedFilePath)
-        {
-            try
-            {
-                using (var sourceStream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read))
-                {
-                    using (var compressedFileStream = new FileStream(compressedFilePath, FileMode.Create, FileAccess.Write))
-                    {
-                        using (var gzipStream = new GZipStream(compressedFileStream, CompressionMode.Compress))
-                        {
-                            sourceStream.CopyTo(gzipStream);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error compressing the log file: {ex.Message}");
-            }
-        }
-
-        private void RenameFile(string currentFilePath, string newFilePath)
-        {
-            try
-            {
-                File.Move(currentFilePath, newFilePath);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error renaming the file: {ex.Message}");
-            }
-        }
+//        private void RenameFile(string currentFilePath, string newFilePath)
+//        {
+//            try
+//            {
+//                File.Move(currentFilePath, newFilePath);
+//            }
+//            catch (Exception ex)
+//            {
+//                Console.WriteLine($"Error renaming the file: {ex.Message}");
+//            }
+//        }
 
 
-        private void Log(LogLevel level, string message)
-        {
-            //$"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")} [{level}] [{origin}] {message}";
-            string logEntry = $"[{level}] {message}";
+//        private void Log(LogLevel level, string message)
+//        {
+//            //$"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")} [{level}] [{origin}] {message}";
+//            string logEntry = $"[{level}] {message}";
 
-            // Write to console
-            System.Console.WriteLine(logEntry);
+//            // Write to console
+//            System.Console.WriteLine(logEntry);
 
-            // Write to log file
-            using (StreamWriter writer = File.AppendText(this._filePath))
-            {
-                writer.WriteLine(logEntry);
-            }
-        }
+//            // Write to log file
+//            using (StreamWriter writer = File.AppendText(this._filePath))
+//            {
+//                writer.WriteLine(logEntry);
+//            }
+//        }
 
-        public void Debug(string message)
-        {
-            if (isDebug)
-            {
-                Log(LogLevel.DEBUG, message);
-            }
-            return;
-        }
+//        public void Debug(string message)
+//        {
+//            if (isDebug)
+//            {
+//                Log(LogLevel.DEBUG, message);
+//            }
+//            return;
+//        }
 
-        public void Info(string message)
-        {
-            Log(LogLevel.INFO, message);
-        }
+//        public void Info(string message)
+//        {
+//            Log(LogLevel.INFO, message);
+//        }
 
-        public void Warn(string message)
-        {
-            Log(LogLevel.WARN, message);
-        }
+//        public void Warn(string message)
+//        {
+//            Log(LogLevel.WARN, message);
+//        }
 
-        public void Error(string message)
-        {
-            Log(LogLevel.ERROR, message);
-        }
-    }
-}
+//        public void Error(string message)
+//        {
+//            Log(LogLevel.ERROR, message);
+//        }
+//    }
+//}

--- a/Storage/JSON.cs
+++ b/Storage/JSON.cs
@@ -1,5 +1,5 @@
 using Newtonsoft.Json;
-using OriBot.Storage2;
+using OriBot.Storage;
 
 public static class JSON {
     public static string stringify(dynamic obj)

--- a/Storage/ObjectStorage.cs
+++ b/Storage/ObjectStorage.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using OriBot.Framework;
 
-namespace OriBot.Storage2
+namespace OriBot.Storage
 {
     public class JObject
     {

--- a/Utilities/Color.cs
+++ b/Utilities/Color.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Oribot.Utilities
+{
+    /// <summary>
+    /// RGB Colors for terminals that support 24-bit colors
+    /// </summary>
+    public class Color
+    {
+        /* ********** **
+        ** ATTRIBUTES **
+        ** ********** */
+        private String ansiCodeTemplate = "\u001b[38;2;r;g;bm";
+        private static String ansiCodeReset = "\u001b[0m";
+        private String ansiCode;
+
+
+        /* *********** **
+        ** CONSTRUCTOR **
+        ** *********** */
+        public Color(int r, int g, int b)
+        {
+            // TODO: check if terminal supports true color
+            ansiCode = ansiCodeTemplate.Replace("r", r.ToString()).Replace("g", g.ToString()).Replace("b", b.ToString());
+        }
+
+
+        /* ******* **
+        ** METHODS **
+        ** ******* */
+
+        /// <summary>
+        /// Returns an ANSI Code to reset the terminal's colors
+        /// </summary>
+        /// <returns>ANSI Code</returns>
+        public static String Reset()
+        {
+            return ansiCodeReset;
+        }
+
+        public override String ToString()
+        {
+            // TODO: Return "" if terminal doesn't support colors
+            return ansiCode;
+        }
+    }
+}

--- a/Utilities/Config.cs
+++ b/Utilities/Config.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using OriBot.Storage;
+
+namespace Oribot.Utilities
+{
+    /// <summary>
+    /// Contains the project configuration.
+    /// </summary>
+    class Config
+    {
+        /* ********** **
+        ** ATTRIBUTES **
+        ** ********** */
+        public static JObject properties;
+
+
+        /* ************ **
+        ** CONSTRUCTORS **
+        ** ************ */
+        static Config()
+        {
+            LoadConfig();
+        }
+
+        // Private contructor to avoid external instantiation
+        private Config() { }
+
+
+        /* ******* **
+        ** METHODS **
+        ** ******* */
+
+        /// <summary>
+        /// Loads the project configuration file.
+        /// </summary>
+        public static void LoadConfig()
+        {
+            // Get the config.json file path
+            String projectDirectory = GetRootDirectory();
+            String configFilePath = Path.Combine(projectDirectory, "config.json");
+
+            // Update properties to load the json data
+            properties = JObject.Load(File.ReadAllText(configFilePath));
+        }
+
+        /// <summary>
+        /// Gets the root directory of the project.
+        /// </summary>
+        /// <returns>String: Root Dir</returns>
+        /// <exception cref="Exception"></exception>
+        public static string GetRootDirectory()
+        {
+            // Store the current root directory
+            string rootDirectory = Directory.GetCurrentDirectory();
+
+            // Loop till there is a valid root directory
+            while (!string.IsNullOrEmpty(rootDirectory))
+            {
+                // Check whether there are any project files in the root directory
+                string[] projectFiles = Directory.GetFiles(rootDirectory, "*.csproj");
+                if (projectFiles.Length > 0)
+                {
+                    return rootDirectory;
+                }
+
+                // Change the root directory to the parent directory
+                rootDirectory = Directory.GetParent(rootDirectory)?.FullName;
+            }
+
+            // If no root director was found throw an exception
+            throw new Exception("Could not find the root directory of the project.");
+        }
+    }
+}

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -1,0 +1,300 @@
+using System;
+using System.IO;
+using System.Text;
+namespace Oribot.Utilities
+{
+    /// <summary>
+    /// A basic logger with support for colors and logs including crash logs.
+    /// </summary>
+    public class Logger
+    {
+        /* ********** **
+        ** ATTRIBUTES **
+        ** ********** */
+
+        // Colors
+        private static readonly Color normalColor = new Color(248, 246, 246);
+        private static readonly Color warningColor = new Color(245, 208, 97);
+        private static readonly Color errorColor = new Color(207, 70, 71);
+        private static readonly Color fatalColor = new Color(255, 0, 255); 
+
+        // Config
+        private static readonly bool debug = Config.properties["logger"]["debugMode"];
+
+        private static readonly String logFolder = Config.properties["logger"]["logFolder"];
+        private static readonly String normalLogFile = Config.properties["logger"]["normalLogFile"];
+        private static readonly String debugLogFile = Config.properties["logger"]["debugLogFile"];
+        private static readonly String crashLogFile = Config.properties["logger"]["crashLogFile"];
+
+        private static readonly String dateTimeFormat = Config.properties["logger"]["fileDateTimeFormat"];
+        private static readonly int crashLogBufferSize = Config.properties["logger"]["crashLogBufferSize"];
+
+        // Printing
+        private const int MAX_CAT_SPACE = 7; 
+
+        private static int previousLogLevel = 0; // 0 = Normal, ... TODO: Change to enum
+        private static int currentLogLevel = 0;
+
+        private static CircularBuffer<String> crashDumpBuffer = new CircularBuffer<String>(crashLogBufferSize); 
+
+        // Writing
+        private static String instanceFileIdentifier = null;
+
+        /* ************ **
+        ** CONSTRUCTORS **
+        ** ************ */
+
+        // To avoid instantiation
+        private Logger()
+        {
+        }
+
+        /// <summary>
+        /// Sets up the crash handling.
+        /// </summary>
+        static Logger() {
+            // Important for crash logs
+            AppDomain.CurrentDomain.UnhandledException += Logger.DumpCrashLog;
+        }
+
+        /* ******* **
+        ** METHODS **
+        ** ******* */
+
+        /// <summary>
+        /// Writes a log to the screen.
+        /// </summary>
+        /// <param name="color"></param>
+        /// <param name="category"></param>
+        /// <param name="message"></param>
+        private static void _Log(Color color, String category, String message)
+        {
+            String unformatted = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}";
+            // TODO: Add config clumping bool
+            String log = $"{(previousLogLevel != currentLogLevel ? "" : "")}{color}{unformatted}{Color.Reset()}";
+
+            crashDumpBuffer.Add(unformatted);
+
+            Console.WriteLine(log);
+        }
+
+        /// <summary>
+        /// Creates a normal info level log.
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Log(String message)
+        {
+            currentLogLevel = 0;
+
+            if (debug)
+            {
+                _Log(normalColor, "info", message);
+                WriteLogsDebug("info", message);
+            }
+            else
+            {
+                WriteLogsNormal("info", message);
+            }
+
+            previousLogLevel = currentLogLevel;
+        }
+
+        /// <summary>
+        /// Creates a warning level log.
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Warning(String message)
+        {
+            currentLogLevel = 1;
+
+            if (debug)
+            {
+                _Log(warningColor, "warning", message);
+                WriteLogsDebug("warning", message);
+            }
+            else
+            {
+                WriteLogsNormal("warning", message);
+            }
+
+            previousLogLevel = currentLogLevel;
+        }
+
+        /// <summary>
+        /// Creates an error level log.
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Error(String message)
+        {
+            currentLogLevel = 2;
+
+            if (debug)
+            {
+                _Log(errorColor, "error", message);
+                WriteLogsDebug("error", message);
+            }
+            else
+            {
+                WriteLogsNormal("error", message);
+            }
+
+            previousLogLevel = currentLogLevel;
+        }
+
+        /// <summary>
+        /// Repeats a given string.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="times"></param>
+        /// <returns>String result</returns>
+        private static String RepeatString(String message, int times) {
+            return new StringBuilder(message.Length * times).Insert(0, message, times).ToString();
+        }
+
+        /// <summary>
+        /// Writes normal logs to the disk.
+        /// </summary>
+        /// <param name="category"></param>
+        /// <param name="message"></param>
+        private static void WriteLogsNormal(String category, String message)
+        {
+            CheckCreateDirectory();
+
+            String fileName = normalLogFile + "_" + CreateInstanceIdentifier() + ".log";
+            String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
+
+            String text = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}\n";
+
+            File.AppendAllText(filePath, text);
+        }
+
+        /// <summary>
+        /// Writes debug logs to the disk.
+        /// </summary>
+        /// <param name="category"></param>
+        /// <param name="message"></param>
+        private static void WriteLogsDebug(String category, String message)
+        {
+            CheckCreateDirectory();
+
+            String fileName = debugLogFile + "_" + CreateInstanceIdentifier() + ".log";
+            String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
+
+            String text = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}\n";
+
+            File.AppendAllText(filePath, text);
+        }
+
+        /// <summary>
+        /// Dumps the crash log to the disk.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        public static void DumpCrashLog(Object sender, UnhandledExceptionEventArgs e)
+        {
+            CheckCreateDirectory();
+
+            Logger.Error("Program crashed!");
+
+            // TODO: Dump circular buffer 
+            String fileName = crashLogFile + "_" + CreateInstanceIdentifier() + ".dump";
+            String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
+
+            Logger.Log($"Creating dump file at {filePath}...");
+
+            foreach (String log in crashDumpBuffer.ToArray())
+            {
+                File.AppendAllText(filePath, log + "\n");
+            }
+
+            Logger.Log("Dump file created!");
+            Logger.Warning("Exiting...");
+            Environment.Exit(0);
+        }
+
+        /// <summary>
+        /// Checks whether the log directory exists, else creates it.
+        /// </summary>
+        private static void CheckCreateDirectory()
+        {
+            String directoryPath = Path.Combine(Config.GetRootDirectory(), logFolder);
+
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+        }
+
+        /// <summary>
+        /// Creates a unique identifier for files using date time data.
+        /// </summary>
+        /// <returns></returns>
+        private static String CreateInstanceIdentifier()
+        {
+            return DateTime.Now.ToString(dateTimeFormat);
+        }
+    }
+
+    /// <summary>
+    /// A data structure that represents a ring/circular buffer.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    class CircularBuffer<T>
+    {
+        /* ********** **
+        ** ATTRIBUTES **
+        ** ********** */
+        private T[] buffer;
+        private int head;
+        private int count;
+
+        /* *********** **
+        ** CONSTRUCTOR **
+        ** *********** */
+
+        /// <summary>
+        /// Creates an empty buffer with a given size.
+        /// </summary>
+        /// <param name="capacity"></param>
+        public CircularBuffer(int capacity)
+        {
+            buffer = new T[capacity];
+            head = 0;
+            count = 0;
+        }
+
+        /* ******* **
+        ** METHODS **
+        ** ******* */
+
+        /// <summary>
+        /// Adds an item to the buffer. If the buffer is overloaded, starts replacing the values from the start.
+        /// </summary>
+        /// <param name="item"></param>
+        public void Add(T item)
+        {
+            buffer[head] = item;
+            head = (head + 1) % buffer.Length;
+
+            if (count < buffer.Length)
+                count++;
+        }
+
+        /// <summary>
+        /// Returns an organized array from the buffer.
+        /// </summary>
+        /// <returns>T[] array</returns>
+        public T[] ToArray()
+        {
+            T[] organizedArray = new T[count];
+
+            int start = (head - count + buffer.Length) % buffer.Length;
+            for (int i = 0; i < count; i++)
+            {
+                organizedArray[i] = buffer[(start + i) % buffer.Length];
+            }
+
+            return organizedArray;
+        }
+    }
+}

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -1,3 +1,0 @@
-# Utilities
-
-changes by MU will go here they said,,

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -1,0 +1,3 @@
+# Utilities
+
+changes by MU will go here they said,,

--- a/config.json
+++ b/config.json
@@ -1,0 +1,13 @@
+{
+    "logger": {
+        "logFolder": "Logs",
+        "debugLogFile": "Debug_Log",
+        "crashLogFile": "Crash_Log",
+        "normalLogFile": "Run",
+        "fileDateTimeFormat": "HH", // TODO: Fix special chars error, i.e :, /, ...
+        "debugMode": true,
+        "clumpLevelsTogether": false,
+        "crashLogBufferSize": 100
+    }
+}
+

--- a/main.cs
+++ b/main.cs
@@ -14,7 +14,7 @@ using OriBot.Framework;
 using Oribot.Utilities;
 
 using OriBot.PassiveHandlers;
-using OriBot.Storage2;
+using OriBot.Storage;
 
 namespace main
 {

--- a/main.cs
+++ b/main.cs
@@ -11,6 +11,7 @@ using Discord.WebSocket;
 
 using OriBot.Commands;
 using OriBot.Framework;
+using Oribot.Utilities;
 
 using OriBot.PassiveHandlers;
 using OriBot.Storage2;
@@ -69,16 +70,16 @@ namespace main
                 switch (sel)
                 {
                     case 1:
-                        Logging.Debug("Be gone");
+                        Logger.Log("Be gone");
                         sel = 0;
                         await Cleanup();
                         break;
                     case 2:
-                        Logging.Info("define help here please lol");
+                        Logger.Log("define help here please lol");
                         sel = 0;
                         break;
                     default:
-                        Logging.Info("'" + input + "' is not reconized as an internal command. Try 'help' for more information.");
+                        Logger.Log("'" + input + "' is not reconized as an internal command. Try 'help' for more information.");
                         sel = 0;
                         break;
                 }
@@ -108,15 +109,15 @@ namespace main
                 await _client.StartAsync();
 
                 // FIXME: perhaps.. remove this? xd
-                Logging.Info("##### Login Successful! #####");
+                Logger.Log("##### Login Successful! #####");
 
                 // Block this task until the program is closed.
                 await Task.Delay(-1);
             }
             catch (System.Exception e)
             {
-                Logging.Error("Task Terminated");
-                Logging.Error(e.ToString());
+                Logger.Error("Task Terminated");
+                Logger.Error(e.ToString());
             }
         }
 
@@ -145,13 +146,13 @@ namespace main
 
         private async Task Cleanup()
         {
-            Logging.Cleanup();
+            //Logging.Cleanup();
             await Task.CompletedTask;
         }
 
         private Task Log(LogMessage msg)
         {
-            Logging.Info(msg.ToString());
+            Logger.Log(msg.ToString());
             return Task.CompletedTask;
         }
     }

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,3 +1,0 @@
-# Utilities
-
-changes by MU will go here they said,,


### PR DESCRIPTION
Changes made:
  - New Utilities namespace
  - A project config handler -> accessed via Config.properties["key"]["subkey"]...
  - New logger
     - Debug Mode
     - Color support (wip: needs to support all terms)
     - Crash logs
     - Configuration category in config.json
     - Currently does instance logs -> since bot will not be rerun a lot, the logs files are currently stored with an identifier which identifies when the bot was run (configurable in config.json -> wip has some bugs - see config.json)
     - Changed to a static constructor so there is no need to add another extra line in MainAsync()
  - Color class which supports rgb colors (just an extra touch)
  - A ring buffer class for handling crash logs so we don't use unnecessary memory -> can be used for any data type
  - Change the `Storage2` namespace to `Storage`
 
Problems:
 - File identifiers have bugs -> you can't use sepecial chars such as /, :, etc. It is going to be fixed in the next PR.
 - Color.cs assumes the terminal has 24-bit color support -> will be changed in next PR to add a check
 - Only logs at a specified folder -> will be changed to log there as well as any other paths specified in the config
 - Need to move to enums for handling log levels *inside* the Logger class.
 - Integration of packing/archiving as in the previous logger, is in the works, not ready for now.
 
Additional Notes:
- The config.json has a property clumpLevelsTogether, which has no effect as of yet -> it will allow for different log level to be clumped together, in case needed.
   - For example:
       [1]
       [1]

       [2]
       ...
-----------------------------
To use the logger, the file must have `using Oribot.Utilities`, and there is no need to instantiate a `Logger` instance. Everything works statically, even the constructor, which mitigates the need for adding `AppDomain.CurrentDomain.UnhandledException += Logger.DumpCrashLog;` in the main function. 

The logger has a debug mode -> which will print logs to the terminal, and a normal log, which just logs to a file. 
The logger has 3 log levels:
- .Log() -> Info
- .Warning() -> Warning
- .Error() -> Error
with a 4th one `Fatal`, on the works.

All log files will have a `.log` extension, whereas a crash logs file will have a `.dump` extension. 

The previous logger file has been commented, to avoid conflicts with the new Logger class, as both have a `Logger` class.