### PR TITLE
Update logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.vs
 /token.txt
 /bin
+
+Logs/

--- a/Utilities/Color.cs
+++ b/Utilities/Color.cs
@@ -20,8 +20,10 @@ namespace Oribot.Utilities
         ** *********** */
         public Color(int r, int g, int b)
         {
-            // TODO: check if terminal supports true color
-            ansiCode = ansiCodeTemplate.Replace("r", r.ToString()).Replace("g", g.ToString()).Replace("b", b.ToString());
+            if (SupportsColor())
+                ansiCode = ansiCodeTemplate.Replace("r", r.ToString()).Replace("g", g.ToString()).Replace("b", b.ToString());
+            else
+                ansiCode = "";
         }
 
 
@@ -38,9 +40,30 @@ namespace Oribot.Utilities
             return ansiCodeReset;
         }
 
+        /// <summary>
+        /// Checks whether the terminal supports color
+        /// </summary>
+        /// <returns>bool: Whether color is supported</returns>
+        private static bool SupportsColor()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return true; // Windows supports color by default
+            }
+            else
+            {
+                string term = Environment.GetEnvironmentVariable("TERM");
+                if (!string.IsNullOrEmpty(term) && term.Contains("color", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public override String ToString()
         {
-            // TODO: Return "" if terminal doesn't support colors
             return ansiCode;
         }
     }

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+
 namespace Oribot.Utilities
 {
     /// <summary>
@@ -17,8 +18,7 @@ namespace Oribot.Utilities
             INFO,
             WARN,
             ERROR,
-            FATAL,
-            NONE
+            FATAL
         }
 
         /* ********** **
@@ -47,8 +47,8 @@ namespace Oribot.Utilities
         // Printing
         private const int MAX_CAT_SPACE = 7; 
 
-        private static LogLevel previousLogLevel = LogLevel.NONE;
-        private static LogLevel currentLogLevel = LogLevel.NONE;
+        private static LogLevel previousLogLevel = LogLevel.DEBUG;
+        private static LogLevel currentLogLevel = LogLevel.DEBUG;
 
         private static CircularBuffer<String> crashDumpBuffer = new CircularBuffer<String>(crashLogBufferSize); 
 

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -234,6 +234,7 @@ namespace Oribot.Utilities
             CheckCreateDirectory();
 
             String fileName = normalLogFile + "_" + CreateInstanceIdentifier() + ".log";
+
             String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
 
             String text = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}\n";
@@ -251,6 +252,7 @@ namespace Oribot.Utilities
             CheckCreateDirectory();
 
             String fileName = debugLogFile + "_" + CreateInstanceIdentifier() + ".log";
+
             String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
 
             String text = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}\n";

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -8,6 +8,19 @@ namespace Oribot.Utilities
     /// </summary>
     public class Logger
     {
+        /* **** ***** **
+        ** DATA TYPES **
+        ** **** ***** */
+        private enum LogLevel
+        {
+            DEBUG,
+            INFO,
+            WARN,
+            ERROR,
+            FATAL,
+            NONE
+        }
+
         /* ********** **
         ** ATTRIBUTES **
         ** ********** */
@@ -16,7 +29,7 @@ namespace Oribot.Utilities
         private static readonly Color normalColor = new Color(248, 246, 246);
         private static readonly Color warningColor = new Color(245, 208, 97);
         private static readonly Color errorColor = new Color(207, 70, 71);
-        private static readonly Color fatalColor = new Color(255, 0, 255); 
+        private static readonly Color fatalColor = new Color(233, 179, 132); 
 
         // Config
         private static readonly bool debug = Config.properties["logger"]["debugMode"];
@@ -29,11 +42,13 @@ namespace Oribot.Utilities
         private static readonly String dateTimeFormat = Config.properties["logger"]["fileDateTimeFormat"];
         private static readonly int crashLogBufferSize = Config.properties["logger"]["crashLogBufferSize"];
 
+        private static readonly bool clumpLogs = Config.properties["logger"]["clumpLevelsTogether"];
+
         // Printing
         private const int MAX_CAT_SPACE = 7; 
 
-        private static int previousLogLevel = 0; // 0 = Normal, ... TODO: Change to enum
-        private static int currentLogLevel = 0;
+        private static LogLevel previousLogLevel = LogLevel.NONE;
+        private static LogLevel currentLogLevel = LogLevel.NONE;
 
         private static CircularBuffer<String> crashDumpBuffer = new CircularBuffer<String>(crashLogBufferSize); 
 
@@ -67,15 +82,48 @@ namespace Oribot.Utilities
         /// <param name="color"></param>
         /// <param name="category"></param>
         /// <param name="message"></param>
-        private static void _Log(Color color, String category, String message)
-        {
-            String unformatted = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}";
-            // TODO: Add config clumping bool
-            String log = $"{(previousLogLevel != currentLogLevel ? "" : "")}{color}{unformatted}{Color.Reset()}";
+        private static void _Log(Color color, LogLevel logLevel, String message)
+        { 
+            String category = null;
+            switch (logLevel)
+            {
+                case LogLevel.DEBUG:
+                    category = "debug";
+                    break;
+                case LogLevel.INFO:
+                    category = "info";
+                    break;
+                case LogLevel.WARN:
+                    category = "warning";
+                    break;
+                case LogLevel.ERROR:
+                    category = "error";
+                    break;
+                case LogLevel.FATAL:
+                    category = "fatal";
+                    break;
+                default:
+                    break;
+            }
 
-            crashDumpBuffer.Add(unformatted);
+            String unformattedLog = $"[ {category.ToUpper()}{RepeatString(" ", (MAX_CAT_SPACE - category.Length))} ] - {message}";
+            crashDumpBuffer.Add(unformattedLog);
 
+            String log = $"{((previousLogLevel != currentLogLevel) && clumpLogs ? "\n" : "")}{color}{unformattedLog}{Color.Reset()}";
             Console.WriteLine(log);
+        }
+
+        public static void Debug(String message)
+        {
+            if (debug)
+            {
+                currentLogLevel = LogLevel.DEBUG;
+
+                _Log(normalColor, LogLevel.DEBUG, message);
+                WriteLogsDebug("debug", message);
+
+                previousLogLevel = currentLogLevel;
+            }
         }
 
         /// <summary>
@@ -84,15 +132,16 @@ namespace Oribot.Utilities
         /// <param name="message"></param>
         public static void Log(String message)
         {
-            currentLogLevel = 0;
+            currentLogLevel = LogLevel.INFO;
 
             if (debug)
             {
-                _Log(normalColor, "info", message);
+                _Log(normalColor, LogLevel.INFO, message);
                 WriteLogsDebug("info", message);
             }
             else
             {
+                _Log(normalColor, LogLevel.INFO, message);
                 WriteLogsNormal("info", message);
             }
 
@@ -105,15 +154,16 @@ namespace Oribot.Utilities
         /// <param name="message"></param>
         public static void Warning(String message)
         {
-            currentLogLevel = 1;
+            currentLogLevel = LogLevel.WARN;
 
             if (debug)
             {
-                _Log(warningColor, "warning", message);
+                _Log(warningColor, LogLevel.WARN, message);
                 WriteLogsDebug("warning", message);
             }
             else
             {
+                _Log(warningColor, LogLevel.WARN, message);
                 WriteLogsNormal("warning", message);
             }
 
@@ -126,16 +176,39 @@ namespace Oribot.Utilities
         /// <param name="message"></param>
         public static void Error(String message)
         {
-            currentLogLevel = 2;
+            currentLogLevel = LogLevel.ERROR;
 
             if (debug)
             {
-                _Log(errorColor, "error", message);
+                _Log(errorColor, LogLevel.ERROR, message);
                 WriteLogsDebug("error", message);
             }
             else
             {
+                _Log(errorColor, LogLevel.ERROR, message);
                 WriteLogsNormal("error", message);
+            }
+
+            previousLogLevel = currentLogLevel;
+        }
+
+        /// <summary>
+        /// Creates an fatal level log.
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Fatal(String message)
+        {
+            currentLogLevel = LogLevel.FATAL;
+
+            if (debug)
+            {
+                _Log(fatalColor, LogLevel.FATAL, message);
+                WriteLogsDebug("fatal", message);
+            }
+            else
+            {
+                _Log(fatalColor, LogLevel.FATAL, message);
+                WriteLogsNormal("fatal", message);
             }
 
             previousLogLevel = currentLogLevel;
@@ -194,9 +267,8 @@ namespace Oribot.Utilities
         {
             CheckCreateDirectory();
 
-            Logger.Error("Program crashed!");
+            Logger.Fatal("Program crashed!");
 
-            // TODO: Dump circular buffer 
             String fileName = crashLogFile + "_" + CreateInstanceIdentifier() + ".dump";
             String filePath = Path.Combine(Path.Combine(Config.GetRootDirectory(), logFolder), fileName);
 
@@ -208,8 +280,6 @@ namespace Oribot.Utilities
             }
 
             Logger.Log("Dump file created!");
-            Logger.Warning("Exiting...");
-            Environment.Exit(0);
         }
 
         /// <summary>

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -4,6 +4,8 @@ using System.Text;
 
 namespace Oribot.Utilities
 {
+    // TODO: Add archiving
+
     /// <summary>
     /// A basic logger with support for colors and logs including crash logs.
     /// </summary>

--- a/config.json
+++ b/config.json
@@ -1,9 +1,9 @@
 {
     "logger": {
         "logFolder": "Logs",
-        "debugLogFile": "Debug_Log", // Debug File name (base)
+        "debugLogFile": "Debug", // Debug File name (base)
         "crashLogFile": "Crash_Log", // Crash dump file name (base)
-        "normalLogFile": "Run", // Normal log file name (base)
+        "normalLogFile": "", // Normal log file name (base)
         "fileDateTimeFormat": "yyyy-MM-dd_HH-mm-ss", // Adds date time data to file
         "debugMode": true, // Whether to print debug logs
         "clumpLevelsTogether": false, // Writes a \n char when levels change

--- a/config.json
+++ b/config.json
@@ -1,13 +1,13 @@
 {
     "logger": {
         "logFolder": "Logs",
-        "debugLogFile": "Debug_Log",
-        "crashLogFile": "Crash_Log",
-        "normalLogFile": "Run",
+        "debugLogFile": "Debug_Log", // Debug File name (base)
+        "crashLogFile": "Crash_Log", // Crash dump file name (base)
+        "normalLogFile": "Run", // Normal log file name (base)
         "fileDateTimeFormat": "HH", // TODO: Fix special chars error, i.e :, /, ...
-        "debugMode": true,
-        "clumpLevelsTogether": false,
-        "crashLogBufferSize": 100
+        "debugMode": true, // Whether to print debug logs
+        "clumpLevelsTogether": false, // Writes a \n char when levels change
+        "crashLogBufferSize": 100 // How many logs will be stored in crash dump
     }
 }
 

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
         "debugLogFile": "Debug_Log", // Debug File name (base)
         "crashLogFile": "Crash_Log", // Crash dump file name (base)
         "normalLogFile": "Run", // Normal log file name (base)
-        "fileDateTimeFormat": "HH", // TODO: Fix special chars error, i.e :, /, ...
+        "fileDateTimeFormat": "yyyy-MM-dd_HH-mm-ss", // Adds date time data to file
         "debugMode": true, // Whether to print debug logs
         "clumpLevelsTogether": false, // Writes a \n char when levels change
         "crashLogBufferSize": 100 // How many logs will be stored in crash dump


### PR DESCRIPTION
Fixed *some* of the previous problems, and updated the logger to have more levels:
- Debug
- Log/Info
- Warn
- Error
- Fatal
 
Log names have been updated as well, as discussed to ISO 8601.
Replaced log level with an enum instead of an int.
New functionality of clumping logs together -> in case one needs to separate levels (default: false)
